### PR TITLE
Feature/scala 2.13 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         spec:
           containers:
           - name: maven
-            image: 'docker.artifactory.a.intuit.com/maven:3.5.3-jdk-8'
+            image: 'docker.artifactory.a.intuit.com/maven:3.9.9-eclipse-temurin-21'
             tty: true
             command:
             - cat
@@ -60,7 +60,7 @@ pipeline {
               - name: shared-build-output
                 mountPath: /var/run/outputs
           - name: sonar-maven
-            image: 'docker.artifactory.a.intuit.com/maven:3.6.0-jdk-11'
+            image: 'docker.artifactory.a.intuit.com/maven:3.9.9-eclipse-temurin-21'
             command:
                 - cat
             tty: true
@@ -124,6 +124,7 @@ pipeline {
       }
       steps {
         mavenBuildPR("-U -B -s settings.xml")
+        mavenBuildPR("-P scala-2.13 -U -B -s settings.xml")
       }
       post {
         success {
@@ -167,6 +168,7 @@ pipeline {
 		          printf 'simplan.system.ci.framework.version=${revisionNo}\nsimplan.system.ci.framework.commitHash=${commitId}' > global/src/main/resources/simplan-framework-manifest.conf
 		        """
 		        mavenBuildCI("-P upload-artifact -Drevision=${revisionNo} -U -B -s settings.xml")
+		        mavenBuildCI("-P upload-artifact,scala-2.13 -Drevision=${revisionNo} -U -B -s settings.xml")
 		      //  gitTag(revisionNo, env.GIT_URL)
 		      }
 		      post {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>pureconfig_${scala.minor.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.pureconfig</groupId>
+            <artifactId>pureconfig-generic_${scala.minor.version}</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/common/src/main/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoader.scala
+++ b/common/src/main/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoader.scala
@@ -12,6 +12,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory.getLogger
 import pureconfig._
 import pureconfig.error.ConfigReaderFailures
+import pureconfig.generic.ProductHint
+import pureconfig.generic.auto._
 
 import java.io.File
 import java.net.URI
@@ -95,7 +97,7 @@ object TypesafeConfigLoader extends Logging {
   def resolveSystemConfiguration(parser: TypesafeConfigLoader): SimplanAppContextConfiguration = {
     logger.info("Resolving AppContext Configs")
     val config = parser.resolveConfig()
-    val configuration = pureconfig.loadConfig[SimplanAppContextConfiguration](config.getConfig(parser.namespace)) match {
+    val configuration = ConfigSource.fromConfig(config.getConfig(parser.namespace)).load[SimplanAppContextConfiguration] match {
       case Right(renderedConfig: SimplanAppContextConfiguration) => renderedConfig
       case Left(failures: ConfigReaderFailures) => throw new SimplanConfigException(failures.toString)
     }
@@ -107,7 +109,7 @@ object TypesafeConfigLoader extends Logging {
   def resolveTaskConfiguration(parser: TypesafeConfigLoader): SimplanTasksConfiguration = {
     logger.info("Resolving Application Dag Configs")
     val config = parser.resolveConfig()
-    val configuration = pureconfig.loadConfig[SimplanTasksConfiguration](config.getConfig(parser.namespace)) match {
+    val configuration = ConfigSource.fromConfig(config.getConfig(parser.namespace)).load[SimplanTasksConfiguration] match {
       case Right(renderedConfig: SimplanTasksConfiguration) => renderedConfig
       case Left(failures: ConfigReaderFailures) => throw new SimplanConfigException(failures.toString)
     }

--- a/common/src/main/scala/com/intuit/data/simplan/common/files/LocalFileUtils.scala
+++ b/common/src/main/scala/com/intuit/data/simplan/common/files/LocalFileUtils.scala
@@ -1,7 +1,5 @@
 package com.intuit.data.simplan.common.files
 
-import org.apache.commons.io.FileUtils
-
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
@@ -11,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 /** @author Abraham, Thomas - tabraham1
  *          Created on 15-Nov-2021 at 10:17 AM
  */
-class LocalFileUtils extends FileUtils {
+class LocalFileUtils extends org.apache.commons.io.FileUtils with FileUtils {
   override def readContent(path: String, charset: String = "UTF-8"): String = org.apache.commons.io.FileUtils.readFileToString(new File(path), charset)
 
   override def exists(path: String): Boolean = new File(path).exists()
@@ -20,7 +18,7 @@ class LocalFileUtils extends FileUtils {
     .map(each => FileListing(each.getAbsolutePath, each.length(), new Date(each.lastModified())))
     .toList
 
-  override def copy(sourcePath: String, destinationPath: String): Boolean = Try(FileUtils.copyDirectory(new File(sourcePath), new File(destinationPath))) match {
+  override def copy(sourcePath: String, destinationPath: String): Boolean = Try(org.apache.commons.io.FileUtils.copyDirectory(new File(sourcePath), new File(destinationPath))) match {
     case Success(_) => true
     case Failure(exception) => throw exception
   }

--- a/common/src/test/resources/test-simplan.conf
+++ b/common/src/test/resources/test-simplan.conf
@@ -1,0 +1,18 @@
+simplan {
+  application {
+    name = TestApp
+    asset = 1234567890
+    environment = test
+    orchestrator = default
+    parent = default
+    region = us-east-1
+    opsOwner = test-owner
+    businessOwner = test-owner
+    source = test
+    runId = test-run-001
+    operatorMappings {}
+  }
+  system {
+    config {}
+  }
+}

--- a/common/src/test/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoaderTest.scala
+++ b/common/src/test/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoaderTest.scala
@@ -1,0 +1,50 @@
+package com.intuit.data.simplan.common.config.parser
+
+import com.typesafe.config.ConfigValueFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class TypesafeConfigLoaderTest extends AnyFunSuite {
+
+  test("load from classpath resource") {
+    val loader = new TypesafeConfigLoader("simplan", List.empty, Map.empty)
+    loader.load("classpath:test-simplan.conf")
+    val rendered = loader.render(None)
+    assert(rendered.contains("TestApp"))
+  }
+
+  test("overrideConfig should override a key in the rendered output") {
+    val loader = new TypesafeConfigLoader("simplan", List.empty, Map.empty)
+    loader.load("classpath:test-simplan.conf")
+    loader.overrideConfig("simplan.application.name", ConfigValueFactory.fromAnyRef("Overridden"))
+    val rendered = loader.render(None)
+    assert(rendered.contains("Overridden"))
+    assert(!rendered.contains("TestApp"))
+  }
+
+  test("isSupportedScheme returns false when no custom fileUtils registered") {
+    val loader = new TypesafeConfigLoader("simplan", List.empty, Map.empty)
+    assert(!loader.isSupportedScheme("s3://some-bucket/path.conf"))
+  }
+
+  test("getFileUtils throws SimplanException for unregistered scheme") {
+    val loader = new TypesafeConfigLoader("simplan", List.empty, Map.empty)
+    intercept[com.intuit.data.simplan.global.exceptions.SimplanException] {
+      loader.getFileUtils("s3")
+    }
+  }
+
+  test("resolveSystemConfiguration parses SimplanAppContextConfiguration from config") {
+    val loader = new TypesafeConfigLoader("simplan", List.empty, Map.empty)
+    loader.load("classpath:test-simplan.conf")
+    val config = TypesafeConfigLoader.resolveSystemConfiguration(loader)
+    assert(config.application.name == "TestApp")
+    assert(config.application.environment == "test")
+  }
+
+  test("hint produces CamelCase field mapping") {
+    import pureconfig.generic.ProductHint
+    val hint = TypesafeConfigLoader.hint[AnyRef]
+    assert(hint != null)
+    assert(hint.isInstanceOf[ProductHint[_]])
+  }
+}

--- a/common/src/test/scala/com/intuit/data/simplan/common/files/LocalFileUtilsTest.scala
+++ b/common/src/test/scala/com/intuit/data/simplan/common/files/LocalFileUtilsTest.scala
@@ -1,0 +1,77 @@
+package com.intuit.data.simplan.common.files
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.File
+import java.nio.file.Files
+
+class LocalFileUtilsTest extends AnyFunSuite {
+
+  val fileUtils = new LocalFileUtils
+
+  test("schemes should contain 'file'") {
+    assert(fileUtils.schemes == List("file"))
+  }
+
+  test("exists should return true for existing file") {
+    val tmp = Files.createTempFile("simplan-test", ".txt").toFile
+    try {
+      assert(fileUtils.exists(tmp.getAbsolutePath))
+    } finally {
+      tmp.delete()
+    }
+  }
+
+  test("exists should return false for non-existent path") {
+    assert(!fileUtils.exists("/tmp/simplan-nonexistent-file-xyz.txt"))
+  }
+
+  test("writeContent should write string to file and readContent should return it") {
+    val tmp = Files.createTempFile("simplan-test", ".txt").toFile
+    try {
+      val content = "hello simplan"
+      fileUtils.writeContent(tmp.getAbsolutePath, content)
+      assert(fileUtils.readContent(tmp.getAbsolutePath) == content)
+    } finally {
+      tmp.delete()
+    }
+  }
+
+  test("list should return files in a directory") {
+    val dir = Files.createTempDirectory("simplan-test-dir").toFile
+    val child = new File(dir, "file1.txt")
+    try {
+      child.createNewFile()
+      val listing = fileUtils.list(dir.getAbsolutePath)
+      assert(listing.nonEmpty)
+      assert(listing.exists(_.fileName == child.getAbsolutePath))
+    } finally {
+      child.delete()
+      dir.delete()
+    }
+  }
+
+  test("copy should copy directory contents to destination") {
+    val src = Files.createTempDirectory("simplan-src").toFile
+    val dst = Files.createTempDirectory("simplan-dst").toFile
+    val srcFile = new File(src, "data.txt")
+    try {
+      srcFile.createNewFile()
+      fileUtils.copy(src.getAbsolutePath, dst.getAbsolutePath)
+      assert(new File(dst, "data.txt").exists())
+    } finally {
+      srcFile.delete()
+      src.delete()
+      new File(dst, "data.txt").delete()
+      dst.delete()
+    }
+  }
+
+  test("LocalFileUtils should be an instance of Simplan FileUtils trait") {
+    assert(fileUtils.isInstanceOf[FileUtils])
+  }
+
+  test("LocalFileUtils should be an instance of Apache Commons FileUtils") {
+    assert(fileUtils.isInstanceOf[org.apache.commons.io.FileUtils])
+  }
+}

--- a/core/src/main/java/com/intuit/data/simplan/core/domain/TableType.java
+++ b/core/src/main/java/com/intuit/data/simplan/core/domain/TableType.java
@@ -1,6 +1,6 @@
 package com.intuit.data.simplan.core.domain;
 
-import scala.Serializable;
+import java.io.Serializable;
 
 /**
  * @author Abraham, Thomas - tabraham1

--- a/core/src/main/scala/com/intuit/data/simplan/core/context/Application.scala
+++ b/core/src/main/scala/com/intuit/data/simplan/core/context/Application.scala
@@ -34,8 +34,11 @@ class Application(val appContext: AppContext) extends Serializable with Logging 
   lazy private val (defaultFiles, userFiles) =
     if (resolvedTaskConfigFiles.isEmpty)
       (appContext.defaultAppContextConfigFiles, appContext.userAppContextConfigFiles)
-    else
-      (appContext.defaultAppContextConfigFiles ++ defaultTaskConfigFiles.toList, appContext.userAppContextConfigFiles ++ userTaskConfigFiles.toList)
+    else {
+      val defaultFiles = appContext.defaultAppContextConfigFiles ++ defaultTaskConfigFiles.toList
+      val userFiles = appContext.userAppContextConfigFiles.filter(userTaskConfigFiles.contains) ++ userTaskConfigFiles.toList
+      (defaultFiles, userFiles)
+    }
 
   lazy val taskConfigs: SimplanTasksConfiguration = {
     val loader = new TypesafeConfigLoader("simplan", defaultFiles, appContext.fileUtilsMap)

--- a/core/src/main/scala/com/intuit/data/simplan/core/opsmetrics/trackers/TaskExecutionTracker.scala
+++ b/core/src/main/scala/com/intuit/data/simplan/core/opsmetrics/trackers/TaskExecutionTracker.scala
@@ -5,6 +5,7 @@ import com.intuit.data.simplan.logging.MetricConstants
 import com.intuit.data.simplan.logging.events.TaskExecutionStatusEvent
 import org.apache.commons.lang.time.DurationFormatUtils
 import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.slf4j.LoggerFactory
 
 import java.text.SimpleDateFormat
@@ -13,8 +14,8 @@ import java.util.TimeZone
 import scala.collection.mutable
 
 /** @author Abraham, Thomas - tabraham1
-  *         Created on 17-Feb-2022 at 6:32 PM
-  */
+ *          Created on 17-Feb-2022 at 6:32 PM
+ */
 case class TaskExecutionTracker(appContext: AppContext, taskName: String, taskIndex: Long) extends Serializable {
   private var startTime: Option[Instant] = None
   @transient lazy private val logger = LoggerFactory.getLogger(classOf[TaskExecutionTracker])
@@ -50,18 +51,16 @@ case class TaskExecutionTracker(appContext: AppContext, taskName: String, taskIn
   def failed(message: String = "Task execution failed", exception: Option[Throwable] = None): Unit = {
     val operationName =
       try {
-        // format is STEP-operationname_
         StringUtils.substringBetween(taskName, "STEP-", "_")
       } catch {
-        // parsing error
-        case ex: Exception => "UNKNOWN"
+        case _: Exception => "UNKNOWN"
       }
     val operation = s"${taskName}-${operationName}"
 
     if (exception.isEmpty)
       emitter.important(new TaskExecutionStatusEvent(message, taskName, taskIndex, MetricConstants.Status.FAILED, startTime, Some(Instant.now)))
     else {
-      val errors = s"{ operation=${operation}; exception=${exception.get.getMessage}}"
+      val errors = s"{ operation=${operation}; exception=${exception.get.getMessage} ; trace=${ExceptionUtils.getStackTrace(exception.get)} }"
       stepInfoFields += ("errors" -> s"[$errors]")
       emitter.important(new TaskExecutionStatusEvent(message, taskName, taskIndex, MetricConstants.Status.FAILED, startTime, Some(Instant.now)), exception.get)
     }

--- a/core/src/test/scala/com/intuit/data/simplan/core/domain/TableTypeTest.scala
+++ b/core/src/test/scala/com/intuit/data/simplan/core/domain/TableTypeTest.scala
@@ -1,0 +1,42 @@
+package com.intuit.data.simplan.core.domain
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+class TableTypeTest extends AnyFunSuite {
+
+  test("TableType should have TEMP, MANAGED and NONE values") {
+    assert(TableType.TEMP != null)
+    assert(TableType.MANAGED != null)
+    assert(TableType.NONE != null)
+  }
+
+  test("TableType values should be retrievable by name") {
+    assert(TableType.valueOf("TEMP") == TableType.TEMP)
+    assert(TableType.valueOf("MANAGED") == TableType.MANAGED)
+    assert(TableType.valueOf("NONE") == TableType.NONE)
+  }
+
+  test("TableType should implement java.io.Serializable") {
+    assert(classOf[java.io.Serializable].isAssignableFrom(classOf[TableType]))
+  }
+
+  test("TableType enum values should be serializable and deserializable") {
+    val original = TableType.MANAGED
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(original)
+    oos.close()
+
+    val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+    val deserialized = ois.readObject().asInstanceOf[TableType]
+    assert(deserialized == original)
+  }
+
+  test("TableType ordinals should be stable") {
+    assert(TableType.TEMP.ordinal() == 0)
+    assert(TableType.MANAGED.ordinal() == 1)
+    assert(TableType.NONE.ordinal() == 2)
+  }
+}

--- a/library-config.yaml
+++ b/library-config.yaml
@@ -5,7 +5,7 @@ asset_alias: Intuit.simplan.simplanframework
 
 mavenSettingsFileId: ibp-maven-settings-file
 artifactoryCredentialsId: artifactory-simplan-framework
-mavenImage: "maven:3.5.3-jdk-8"
+mavenImage: "maven:3.9.9-eclipse-temurin-21"
 MAIN_BRANCH: "master"
 groupId: com.intuit.Simplan.simplan-framework
 artifactId: simplan-framework

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <revision>1.0.0-SNAPSHOT</revision>
 
-        <scala.version>2.12.12</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.minor.version>2.12</scala.minor.version>
         <scala-parser-combinators.version>1.1.2</scala-parser-combinators.version>
 
@@ -33,7 +33,7 @@
 
         <slf4j.version>1.7.36</slf4j.version>
 
-        <pureconfig.version>0.9.0</pureconfig.version>
+        <pureconfig.version>0.17.4</pureconfig.version>
 
         <jackson.version>2.15.2</jackson.version>
 <!--        <jackson-module-caseclass.version>1.1.1</jackson-module-caseclass.version>-->
@@ -48,22 +48,22 @@
         <httpcomponents.version>4.5.14</httpcomponents.version>
 
 
-        <org.scalatest.version>3.0.4</org.scalatest.version>
+        <org.scalatest.version>3.2.15</org.scalatest.version>
         <junit-version>4.13.1</junit-version>
 
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <java.version>1.8</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
         <jacoco.enabled>true</jacoco.enabled>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
         <releasedeployrepo>https://artifactory.a.intuit.com/artifactory/maven.Simplan.simplan-releases
         </releasedeployrepo>
         <snapshotdeployrepo>https://artifactory.a.intuit.com/artifactory/maven.Simplan.simplan-snapshots
         </snapshotdeployrepo>
         <central.repo>https://artifact.intuit.com/artifactory/maven-proxy</central.repo>
         <encoding>UTF-8</encoding>
-        <scoverage.plugin.version>1.4.1</scoverage.plugin.version>
+        <scoverage.plugin.version>2.0.2</scoverage.plugin.version>
 
         <kafka-clients.version>3.2.3</kafka-clients.version>
     </properties>
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>com.github.scopt</groupId>
                 <artifactId>scopt_${scala.minor.version}</artifactId>
-                <version>3.7.1</version>
+                <version>4.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -164,6 +164,17 @@
             <dependency>
                 <groupId>com.github.pureconfig</groupId>
                 <artifactId>pureconfig_${scala.minor.version}</artifactId>
+                <version>${pureconfig.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.scala-lang</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.pureconfig</groupId>
+                <artifactId>pureconfig-generic_${scala.minor.version}</artifactId>
                 <version>${pureconfig.version}</version>
                 <exclusions>
                     <exclusion>
@@ -271,6 +282,37 @@
     </repositories>
 
     <profiles>
+        <!-- Scala 2.12 is the default build. Adds the macro-paradise compiler arg only valid in 2.12. -->
+        <profile>
+            <id>scala-2.12</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <configuration>
+                            <args>
+                                <arg>-Xmacro-settings:materialize-derivations</arg>
+                            </args>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Scala 2.13 cross-build: override scala version and compatible dependency versions -->
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.version>2.13.12</scala.version>
+                <scala.minor.version>2.13</scala.minor.version>
+                <scala-parser-combinators.version>1.1.2</scala-parser-combinators.version>
+            </properties>
+        </profile>
+
         <profile>
             <id>upload-artifact</id>
             <distributionManagement>
@@ -321,16 +363,16 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>4.8.1</version>
                 <configuration>
                     <scalaCompatVersion>${scala.minor.version}</scalaCompatVersion>
                     <scalaVersion>${scala.version}</scalaVersion>
-                    <args>
-                        <arg>-Xmacro-settings:materialize-derivations</arg>
-                    </args>
                     <jvmArgs>
                         <jvmArg>-Xms128m</jvmArg>
                         <jvmArg>-Xmx1024m</jvmArg>
+                        <jvmArg>--add-opens=java.base/java.lang=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=java.base/java.util=ALL-UNNAMED</jvmArg>
+                        <jvmArg>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvmArg>
                     </jvmArgs>
                 </configuration>
                 <executions>
@@ -380,6 +422,7 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>
+                    <suffixes>Test|Spec|Suite</suffixes>
                 </configuration>
                 <executions>
                     <execution>
@@ -393,9 +436,9 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>${scoverage.plugin.version}</version>
                 <configuration>
-                                        <scalaVersion>${scala.version}</scalaVersion>
+                    <scalaVersion>${scala.version}</scalaVersion>
                     <highlighting>true</highlighting>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <pureconfig.version>0.9.0</pureconfig.version>
 
-        <jackson.version>2.19.0</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
 <!--        <jackson-module-caseclass.version>1.1.1</jackson-module-caseclass.version>-->
 
         <antlr4.version>4.7.1</antlr4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <pureconfig.version>0.9.0</pureconfig.version>
 
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.19.0</jackson.version>
 <!--        <jackson-module-caseclass.version>1.1.1</jackson-module-caseclass.version>-->
 
         <antlr4.version>4.7.1</antlr4.version>
@@ -194,36 +194,44 @@
 <!--                <artifactId>jcl-over-slf4j</artifactId>-->
 <!--                <version>${slf4j.version}</version>-->
 <!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--                <artifactId>jackson-core</artifactId>-->
+<!--                <version>${jackson.version}</version>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>com.fasterxml.jackson.datatype</groupId>-->
+<!--                <artifactId>jackson-datatype-jsr310</artifactId>-->
+<!--                <version>${jackson.version}</version>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--                <artifactId>jackson-annotations</artifactId>-->
+<!--                <version>${jackson.version}</version>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--                <artifactId>jackson-databind</artifactId>-->
+<!--                <version>${jackson.version}</version>-->
+<!--            </dependency>-->
+<!--            <dependency>-->
+<!--                <groupId>com.fasterxml.jackson.module</groupId>-->
+<!--                <artifactId>jackson-module-scala_${scala.minor.version}</artifactId>-->
+<!--                <version>${jackson.version}</version>-->
+<!--                <exclusions>-->
+<!--                    <exclusion>-->
+<!--                        <groupId>org.scala-lang</groupId>-->
+<!--                        <artifactId>scala-library</artifactId>-->
+<!--                    </exclusion>-->
+<!--                </exclusions>-->
+<!--            </dependency>-->
+
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-scala_${scala.minor.version}</artifactId>
-                <version>${jackson.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.scala-lang</groupId>
-                        <artifactId>scala-library</artifactId>
-                    </exclusion>
-                </exclusions>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary
 - Add \`-P scala-2.13\` Maven profile to cross-build JARs for both Scala 2.12 and 2.13; Jenkins BUILDING RELEASE now publishes both \`_2.12\` and \`_2.13\` artifacts sequentially
  - Upgrade to Java 17 compiler target (Java 21 JVM) for Spark 4.x compatibility; Jenkins images updated to \`eclipse-temurin-21\`                                                                     
  - Migrate pureconfig 0.9.0 → 0.17.4, fix \`LocalFileUtils\` inheritance chain, fix \`TableType\` to use \`java.io.Serializable\` (removed in Scala 2.13)      

  ## Test plan                                                                                                                                                                                         
  - [x] \`mvn clean install -B\` — 19 tests pass on Scala 2.12 + Java 21                                                                                                                               
  - [x] \`mvn clean install -P scala-2.13 -B\` — 19 tests pass on Scala 2.13 + Java 21                                                                                                                 