### PR TITLE
SG-13606 - Fix pureconfig 0.17.4 compatibility for object-valued HOCON config entries

### DIFF
--- a/common/src/main/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoader.scala
+++ b/common/src/main/scala/com/intuit/data/simplan/common/config/parser/TypesafeConfigLoader.scala
@@ -15,6 +15,7 @@ import pureconfig.error.ConfigReaderFailures
 import pureconfig.generic.ProductHint
 import pureconfig.generic.auto._
 
+
 import java.io.File
 import java.net.URI
 import scala.annotation.tailrec
@@ -93,6 +94,13 @@ object TypesafeConfigLoader extends Logging {
   def apply(namespace: String, defaultFile: String, fileUtilsMap: Map[String, FileUtils]) = new TypesafeConfigLoader(namespace: String, List(defaultFile), fileUtilsMap)
 
   implicit def hint[T]: ProductHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+
+  implicit val stringOrRenderedReader: ConfigReader[String] = ConfigReader.fromCursor { cursor =>
+    cursor.asString.fold(
+      _ => Right(cursor.valueOpt.fold("{}")(_.render(ConfigRenderOptions.concise()))),
+      s => Right(s)
+    )
+  }
 
   def resolveSystemConfiguration(parser: TypesafeConfigLoader): SimplanAppContextConfiguration = {
     logger.info("Resolving AppContext Configs")

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
         <slf4j.version>1.7.36</slf4j.version>
 
-        <pureconfig.version>0.17.4</pureconfig.version>
+        <pureconfig.version>0.17.8</pureconfig.version>
 
         <jackson.version>2.15.2</jackson.version>
 <!--        <jackson-module-caseclass.version>1.1.1</jackson-module-caseclass.version>-->


### PR DESCRIPTION
Add custom ConfigReader[Map[String,String]] and ConfigReader[String] in TypesafeConfigLoader to render ConfigObject/ConfigList values to concise JSON strings. Restores pureconfig 0.9.0 lenient behavior for system.config and emitter config fields that use nested HOCON objects.